### PR TITLE
SamsaBuffer.encodeInstance() and other worker functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "samsa-core",
-  "version": "2.0.9",
+  "version": "2.0.11",
   "main": "index.js",
   "author": "Laurence Penney <lorp@lorp.org>",
   "license": "Apache-2.0",


### PR DESCRIPTION
Main change is SamsaBuffer.encodeInstance(instance, options), which creates a static TTF in memory at the current position.

- instance is a SamsaInstance
- options has
   - format that defaults to "truetype"
   - checkSums: if true, perform checksums; else don’t (default)

It is the caller’s responsibility to guess the minimum memory requirement for the binary font, and ensure the buffer is large enough. Often the memory will be copied somewhere else immediately after the binary is created. This is necessary, for example, to create an ArrayBuffer for passing as the source argment to the FontFace constructor. However, if we are creating a base64 version of the font or saving it as a file, then we can specify the intended binary length in functions that create the base64 string or file.